### PR TITLE
Modify path checking

### DIFF
--- a/CGNS/MAP/SIDStoPython.c
+++ b/CGNS/MAP/SIDStoPython.c
@@ -278,20 +278,20 @@ static int s2p_issubpath(char *subpathtofind, char* currentpath, int exact)
 	}
 	if (l_subpathtofind > l_currentpath)
 	{
-		if (!strncmp(subpathtofind, currentpath, l_currentpath))
+		if (!strncmp(subpathtofind, currentpath, l_currentpath) &&
+		    subpathtofind[l_currentpath] == '/')
 		{
 			return 1;
 		}
-		else
-		{
-			return 0;
-		}
 	}
-	if ((l_subpathtofind <= l_currentpath)
-		&& (!strncmp(subpathtofind, currentpath, l_subpathtofind)))
+	else 
 	{
-		if (l_currentpath == l_subpathtofind) { return 1; }
-		else if (currentpath[l_subpathtofind] == '/') { return 1; }
+		/* (l_subpathtofind <= l_currentpath) */
+		if (!strncmp(subpathtofind, currentpath, l_subpathtofind))
+		{
+			if (l_currentpath == l_subpathtofind) { return 1; }
+			else if (currentpath[l_subpathtofind] == '/') { return 1; }
+		}
 	}
 	return 0;
 }


### PR DESCRIPTION
#26 issue is due to path length comparison messing with path checking.
/base/zone1 and /base/zone10  are matched while they should not since /base/zone1 is included in /base/zone10 but is not a root path.
The tricky just add a check for the next character at position len(/base/zone1) in /base/zone10 it will find "0" and if it was a root path like for len(/base) it will find "/" .