### PR TITLE
Add an option to deactivate check

### DIFF
--- a/CGNS/PAT/cgnsutils.py
+++ b/CGNS/PAT/cgnsutils.py
@@ -2195,7 +2195,7 @@ def zipTypeOrNameList(tlist: List, nlist: List) -> List[List]:
     w = []
     r = []
     z = len(tlist)
-    for b in range(2 ** z):
+    for b in range(2**z):
         w.append([int(x) for x in "{0:0{width}{base}}".format(b, base="b", width=z)])
     for b in w:
         h = []

--- a/CGNS/PAT/cgnsutils.py
+++ b/CGNS/PAT/cgnsutils.py
@@ -1608,7 +1608,7 @@ def removeFirstPathItem(path: str) -> str:
 
 
 # --------------------------------------------------
-def getNodeByPath(tree: TreeNode, path: str) -> Optional[TreeNode]:
+def getNodeByPath(tree: TreeNode, path: str, check: bool = True) -> Optional[TreeNode]:
     """
     Returns the CGNS/Python node with the argument path::
 
@@ -1643,7 +1643,7 @@ def getNodeByPath(tree: TreeNode, path: str) -> Optional[TreeNode]:
     path = getPathNormalize(path)
     if path in ["", "/", "."]:
         return tree
-    if not checkPath(path):
+    if check and not checkPath(path):
         return None
     lpath = path.split("/")
     if lpath[0] == "":

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,8 +19,8 @@ source_suffix = ".txt"
 import os
 
 master_doc = os.environ["PYCGNSDOC"]
-project = u"pyCGNS"
-copyright = u"2001-2016, Marc Poinot"
+project = "pyCGNS"
+copyright = "2001-2016, Marc Poinot"
 version = "4"
 release = "4.2.0"
 unused_docs = ["license.txt"]
@@ -45,8 +45,8 @@ latex_documents = [
     (
         os.environ["PYCGNSDOC"],
         "pyCGNS_%s.tex" % os.environ["PYCGNSMOD"],
-        u"pyCGNS.%s/Manual" % os.environ["PYCGNSMOD"],
-        u"Marc Poinot",
+        "pyCGNS.%s/Manual" % os.environ["PYCGNSMOD"],
+        "Marc Poinot",
         "manual",
         False,
     ),


### PR DESCRIPTION
Sometime it is faster to not check node name validity when it is within application memory, because the application is responsible and know what is going on with its temporary generated own names.