### PR TITLE
keep root id alive

### DIFF
--- a/CGNS/MAP/SIDStoPython.c
+++ b/CGNS/MAP/SIDStoPython.c
@@ -326,8 +326,8 @@ static int s2p_popHDF(s2p_ctx_t *context)
   S2P_TRACE(("# CHL:pop context [%d]\n", context->hdf_idx));
   if (context->hdf_idx > 0)
   {
-    L3_decRef(context->hdf_stk[context->hdf_idx]->l3db,
-      context->hdf_stk[context->hdf_idx]->l3db->root_id);
+    //L3_decRef(context->hdf_stk[context->hdf_idx]->l3db,
+    //  context->hdf_stk[context->hdf_idx]->l3db->root_id);
     context->hdf_idx--;
   }
   return context->hdf_idx;


### PR DESCRIPTION
When L3_decRef is called and there is only one user of the linked rootid. The rootid of the linked file is release.
This leads to a BAD ROOT error later as we do not reopen the root node.
This patch should help with multiple links to the same file but the impact on #91 is unknown.

An other fix would be to keep the decRef and to reopen the root id of linked file but it seems less efficient.