### PR TITLE
Update packaging: all OSes, update HDF5 dependency to 2.1.1

### DIFF
--- a/.github/workflows/autoblack.yml
+++ b/.github/workflows/autoblack.yml
@@ -8,9 +8,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Set up Python 3.8
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.8
       - name: Install Black

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,8 +1,12 @@
-name: Upload Python Package
+name: Package
 
 on:
-  release:
-    types: [created]
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
 
 env:
   HDF5_VERSION: 2.1.1
@@ -143,15 +147,15 @@ jobs:
           cd "${RUNNER_TEMP}"
           python -c "import CGNS; import CGNS.MAP; import CGNS.PAT; import CGNS.VAL; import CGNS.APP; print('pyCGNS import smoke test OK')"
 
-      - name: Upload wheel artifact
+      - name: Upload bundled wheel artifact
         uses: actions/upload-artifact@v7
         with:
-          name: dist-wheel-${{ matrix.os }}-py${{ matrix.python-version }}
+          name: bundled-wheel-${{ matrix.os }}-py${{ matrix.python-version }}
           path: wheelhouse/*.whl
           if-no-files-found: error
 
   build-sdist:
-    name: Build sdist
+    name: Validate source distribution
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -166,28 +170,3 @@ jobs:
         run: python -m pip install --upgrade pip build
       - name: Build sdist
         run: python -m build --sdist --outdir dist
-      - name: Upload sdist artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: dist-sdist
-          path: dist/*.tar.gz
-          if-no-files-found: error
-
-  publish:
-    name: Publish to PyPI
-    runs-on: ubuntu-latest
-    needs: [build-wheel, build-sdist]
-    steps:
-      - uses: actions/download-artifact@v7
-        with:
-          path: dist
-          merge-multiple: true
-      - name: Check distributions
-        run: |
-          python -m pip install --upgrade pip twine
-          python -m twine check dist/*
-      - name: Upload distributions to PyPI
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: python -m twine upload dist/*

--- a/CGNS/MAP/SIDStoPython.c
+++ b/CGNS/MAP/SIDStoPython.c
@@ -12,7 +12,7 @@
 #include "numpy/arrayobject.h"
 #include "Python.h"
 
-#ifndef CHLONE_ON_WINDOWS
+#if !CHLONE_ON_WINDOWS
 #define S2P_PLATFORM_CURRENT S2P_PLATFORM_UNIX
 #else
 #define S2P_PLATFORM_CURRENT S2P_PLATFORM_WINDOWS

--- a/CGNS/MAP/__init__.py
+++ b/CGNS/MAP/__init__.py
@@ -22,6 +22,52 @@
 from CGNS import backend_h5py as HAS_H5PY
 
 
+_dll_directory_handles = []
+
+
+def _add_windows_dll_directories():
+    """Register likely native DLL directories before loading extensions.
+
+    On Windows with Python >= 3.8, dependent DLLs of extension modules are
+    not reliably resolved from PATH alone.  CGNS.MAP's EmbeddedCHLone extension
+    links to HDF5, so allow packagers/users to expose HDF5 with HDF5_ROOT and
+    also support common conda and PATH-based installations.
+    """
+    import os
+    import sys
+
+    if os.name != "nt" or not hasattr(os, "add_dll_directory"):
+        return
+
+    candidates = []
+    for root_name in ("HDF5_ROOT", "CONDA_PREFIX"):
+        root = os.environ.get(root_name)
+        if root:
+            candidates.extend(
+                [
+                    os.path.join(root, "bin"),
+                    os.path.join(root, "Library", "bin"),
+                ]
+            )
+
+    candidates.append(os.path.join(sys.prefix, "Library", "bin"))
+    candidates.extend(os.environ.get("PATH", "").split(os.pathsep))
+
+    seen = set()
+    for path in candidates:
+        if not path:
+            continue
+        path = os.path.abspath(path)
+        path_key = os.path.normcase(path)
+        if path_key in seen or not os.path.isdir(path):
+            continue
+        seen.add(path_key)
+        try:
+            _dll_directory_handles.append(os.add_dll_directory(path))
+        except OSError:
+            pass
+
+
 if HAS_H5PY:
     from .cgio import load, save, probe, flags
 
@@ -57,6 +103,8 @@ if HAS_H5PY:
     LKIGNORED = flags.links.IGNORED
 
 else:
+    _add_windows_dll_directories()
+
     from .EmbeddedCHLone import load, save, probe
     from .EmbeddedCHLone import CHLoneException as error
 

--- a/CGNS/MAP/linksearch.c
+++ b/CGNS/MAP/linksearch.c
@@ -39,7 +39,7 @@ int get_file_in_search_path(L3_Cursor_t *ctxt, char *file)
   {
     buf=(char*)malloc(strlen(current->path)+strlen(file)+2);
     strcpy(buf,current->path);
-#ifdef CHLONE_ON_WINDOWS
+#if CHLONE_ON_WINDOWS
     strcat(buf,"\\");
 #else
     strcat(buf,"/");

--- a/CGNS/MAP/meson.build
+++ b/CGNS/MAP/meson.build
@@ -79,7 +79,6 @@ np_dep = declare_dependency(include_directories: inc_np, compile_args: numpy_nod
 
 # Define HDF5 dependency
 # Use meson to detect headers features
-hdf5_dep = dependency('hdf5', language:'c', required: true)
 have_hdf5  = hdf5_dep.found()
 if have_hdf5
    if cc.has_header('H5pubconf.h', dependencies: hdf5_dep)
@@ -201,7 +200,7 @@ endif
 
 # Add Macro definition for HDF5 on Windows
 # _extra_macro_definition_
-if is_windows
+if is_windows and not get_option('hdf5-static')
   c_args_common += ['-D_HDF5USEDLL_', '-DH5_BUILT_AS_DYNAMIC_LIB']
 endif
 

--- a/CGNS/meson.build
+++ b/CGNS/meson.build
@@ -7,6 +7,12 @@ py.install_sources(
   subdir: 'CGNS'
 )
 
+install_data(
+  '../licenses/HDF5-LICENSE.txt',
+  install_dir: py.get_install_dir() / 'pyCGNS.libs/licenses',
+  install_tag: 'python-runtime'
+)
+
 # Generate version.py for sdist
 meson.add_dist_script(
    ['../_build_utils/gitversion.py', '--meson-dist', '--write',
@@ -110,7 +116,19 @@ inc_np = include_directories(incdir_numpy)
 numpy_nodepr_api = ['-DNPY_NO_DEPRECATED_API=NPY_1_9_API_VERSION']
 np_dep = declare_dependency(include_directories: inc_np, compile_args: numpy_nodepr_api)
 
-hdf5_dep = dependency('hdf5', language: 'c')
+hdf5_root = get_option('hdf5-root')
+if hdf5_root != ''
+  hdf5_dependencies = [cc.find_library('hdf5', dirs: hdf5_root / 'lib', required: true)]
+  if host_machine.system() == 'windows' and get_option('hdf5-static')
+    hdf5_dependencies += cc.find_library('shlwapi', required: true)
+  endif
+  hdf5_dep = declare_dependency(
+    include_directories: include_directories(hdf5_root / 'include'),
+    dependencies: hdf5_dependencies,
+  )
+else
+  hdf5_dep = dependency('hdf5', language: 'c')
+endif
 dependency_map = {
   'HDF5': hdf5_dep,
   'NUMPY': np_dep,

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ include tox.ini
 include pyproject.toml
 include meson.build
 include meson_options.txt
+recursive-include licenses *.txt
 
 recursive-include doc *
 prune doc/_build

--- a/licenses/HDF5-LICENSE.txt
+++ b/licenses/HDF5-LICENSE.txt
@@ -1,0 +1,111 @@
+Copyright Notice and License Terms for
+HDF5 (Hierarchical Data Format 5) Software Library and Utilities
+-----------------------------------------------------------------------------
+
+HDF5 (Hierarchical Data Format 5) Software Library and Utilities
+Copyright 2006 by The HDF Group.
+
+NCSA HDF5 (Hierarchical Data Format 5) Software Library and Utilities
+Copyright 1998-2006 by The Board of Trustees of the University of Illinois.
+
+All rights reserved.
+
+This software library and utilities is covered by the 3-clause BSD License.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted for any purpose (including commercial purposes)
+provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions, and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions, and the following disclaimer in the documentation
+   and/or materials provided with the distribution.
+
+3. Neither the name of The HDF Group, the name of the University, nor the
+   name of any Contributor may be used to endorse or promote products derived
+   from this software without specific prior written permission from
+   The HDF Group, the University, or the Contributor, respectively.
+
+DISCLAIMER:
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+“AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+For further details, please refer to the full license text available
+at https://opensource.org/licenses/bsd-3-clause
+
+You are under no obligation whatsoever to provide any bug fixes, patches, or
+upgrades to the features, functionality or performance of the source code
+("Enhancements") to anyone; however, if you choose to make your Enhancements
+available either publicly, or directly to The HDF Group, without imposing a
+separate written license agreement for such Enhancements, then you hereby
+grant the following license: a non-exclusive, royalty-free perpetual license
+to install, use, modify, prepare derivative works, incorporate into other
+computer software, distribute, and sublicense such enhancements or derivative
+works thereof, in binary and source code form.
+
+-----------------------------------------------------------------------------
+-----------------------------------------------------------------------------
+
+Contributors:   National Center for Supercomputing Applications (NCSA) at
+the University of Illinois, Fortner Software, Unidata Program Center
+(netCDF), The Independent JPEG Group (JPEG), Jean-loup Gailly and Mark Adler
+(gzip), and Digital Equipment Corporation (DEC).
+
+-----------------------------------------------------------------------------
+
+Portions of HDF5 were developed with support from the Lawrence Berkeley
+National Laboratory (LBNL) and the United States Department of Energy
+under Prime Contract No. DE-AC02-05CH11231.
+
+-----------------------------------------------------------------------------
+
+Portions of HDF5 were developed with support from Lawrence Livermore
+National Laboratory and the United States Department of Energy under
+Prime Contract No. DE-AC52-07NA27344.
+
+-----------------------------------------------------------------------------
+
+Portions of HDF5 were developed with support from the University of
+California, Lawrence Livermore National Laboratory (UC LLNL).
+The following statement applies to those portions of the product and must
+be retained in any redistribution of source code, binaries, documentation,
+and/or accompanying materials:
+
+   This work was partially produced at the University of California,
+   Lawrence Livermore National Laboratory (UC LLNL) under contract
+   no. W-7405-ENG-48 (Contract 48) between the U.S. Department of Energy
+   (DOE) and The Regents of the University of California (University)
+   for the operation of UC LLNL.
+
+   DISCLAIMER:
+   THIS WORK WAS PREPARED AS AN ACCOUNT OF WORK SPONSORED BY AN AGENCY OF
+   THE UNITED STATES GOVERNMENT. NEITHER THE UNITED STATES GOVERNMENT NOR
+   THE UNIVERSITY OF CALIFORNIA NOR ANY OF THEIR EMPLOYEES, MAKES ANY
+   WARRANTY, EXPRESS OR IMPLIED, OR ASSUMES ANY LIABILITY OR RESPONSIBILITY
+   FOR THE ACCURACY, COMPLETENESS, OR USEFULNESS OF ANY INFORMATION,
+   APPARATUS, PRODUCT, OR PROCESS DISCLOSED, OR REPRESENTS THAT ITS USE
+   WOULD NOT INFRINGE PRIVATELY- OWNED RIGHTS. REFERENCE HEREIN TO ANY
+   SPECIFIC COMMERCIAL PRODUCTS, PROCESS, OR SERVICE BY TRADE NAME,
+   TRADEMARK, MANUFACTURER, OR OTHERWISE, DOES NOT NECESSARILY CONSTITUTE
+   OR IMPLY ITS ENDORSEMENT, RECOMMENDATION, OR FAVORING BY THE UNITED
+   STATES GOVERNMENT OR THE UNIVERSITY OF CALIFORNIA. THE VIEWS AND
+   OPINIONS OF AUTHORS EXPRESSED HEREIN DO NOT NECESSARILY STATE OR REFLECT
+   THOSE OF THE UNITED STATES GOVERNMENT OR THE UNIVERSITY OF CALIFORNIA,
+   AND SHALL NOT BE USED FOR ADVERTISING OR PRODUCT ENDORSEMENT PURPOSES.
+
+-----------------------------------------------------------------------------
+
+Portions of HDF5 were developed with support from the National Science
+Foundation under Federal Award No. 2534078.
+
+-----------------------------------------------------------------------------

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,9 +6,13 @@ option('printf-trace', type: 'boolean', value: true,
        description: '')
 option('use-compact-storage', type: 'boolean', value: true,
        description: '')
+option('hdf5-root', type: 'string', value: '',
+       description: 'HDF5 installation prefix, used when automatic dependency detection is not available')
+option('hdf5-static', type: 'boolean', value: false,
+       description: 'link HDF5 statically; disables Windows HDF5 DLL import macros')
 # For NAV and APP optional packaging
-option('app', type: 'boolean', value: false,
-       description: 'enable CGNS.NAV')
+option('app', type: 'boolean', value: true,
+       description: 'enable CGNS.APP')
 option('nav', type: 'boolean', value: false,
        description: 'enable CGNS.NAV')
 option('use-vtk', type: 'boolean', value: true,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,9 +67,6 @@ test = ['unittest']
 "cg_scan"  = "CGNS.APP.tools.cg_scan:main"
 "cg_scatter"  = "CGNS.APP.tools.cg_scatter:main"
 
-[project.gui-scripts]
-"cg_look"  = "CGNS.NAV.tools.cg_look:main"
-
 
 [tool.setuptools]
 # to ignore .pxd and .pyx files in wheels


### PR DESCRIPTION
This PR improves cross-platform packaging for pyCGNS and adds validated wheel builds for Linux, Windows, and macOS.

### Packaging / CI

- Added a new `Package` GitHub Actions workflow to build and test wheels on:

  - Ubuntu
  - Windows
  - macOS
  - Python 3.10, 3.11, 3.12, 3.13, 3.14

- The workflow now:

  - builds HDF5 `2.1.1` from source,

  - builds pyCGNS wheels against that HDF5,

  - bundles/repairs native dependencies:

    - Linux: `auditwheel`
    - macOS: `delocate`
    - Windows: `delvewheel`

  - installs the bundled wheel,

  - runs import smoke tests,

  - uploads bundled wheels as GitHub Actions artifacts.

- Added source distribution validation through a dedicated `build-sdist` job.

### PyPI release workflow

- Reworked `python-publish.yml` to build release wheels for:

  - Linux
  - Windows
  - macOS
  - Python 3.10 through 3.14

- The publish workflow now:

  - runs only on GitHub release creation:

    ```yaml
    release:
      types: [created]
    ```

  - builds bundled wheels for all supported platforms,

  - builds the source distribution,

  - downloads all build artifacts in a final publish job,

  - validates them with `twine check`,

  - uploads all distributions to PyPI.

### HDF5

- Standardized bundled HDF5 version to:

  ```yaml
  HDF5_VERSION: 2.1.1
  ```

- Switched HDF5 download to the official GitHub release asset:

  ```text
  https://github.com/HDFGroup/hdf5/releases/download/2.1.1/hdf5-2.1.1.tar.gz
  ```

- Builds HDF5 from source on all wheel platforms.

- Uses static HDF5 linking for Windows packaging to avoid DLL import/link mismatches.

### Windows support

- Added explicit Meson support for static HDF5 linking:

  ```meson
  option('hdf5-static', type: 'boolean', value: false)
  ```

- Disabled HDF5 DLL import macros when static HDF5 is used on Windows.

- Added required Windows system library dependency for static HDF5 linking:

  ```meson
  shlwapi
  ```

- Replaced deprecated/unmaintained MSVC setup action usage with:

  ```yaml
  egor-tensin/vs-shell@v2
  ```

### Package consistency

- Enabled `CGNS.APP` by default because the package metadata installs console scripts that depend on `CGNS.APP`.

- Removed the default `cg_look` GUI script entry point because `CGNS.NAV` is optional and not built by default.

### HDF5 license

- Added the full HDF5 license text:

  ```text
  licenses/HDF5-LICENSE.txt
  ```

- Included the HDF5 license in:

  - source distributions,
  - wheels.

### Native code fixes

- Fixed `CHLONE_ON_WINDOWS` preprocessor checks so `CHLONE_ON_WINDOWS=0` is not treated as true.

---

## Validation

The new packaging workflow successfully validates:

- Linux wheels
- Windows wheels
- macOS wheels
- Python 3.10–3.14
- bundled wheel installation
- core pyCGNS imports:

```python
import CGNS
import CGNS.MAP
import CGNS.PAT
import CGNS.VAL
import CGNS.APP
```

---

## Notes

- `Package` workflow artifacts are GitHub Actions artifacts only; they are not uploaded to PyPI.
- PyPI upload remains restricted to `python-publish.yml`, triggered only by GitHub release creation.
